### PR TITLE
Run pytests on ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest
-    name: pytest tests
+    name: pytest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -56,5 +56,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-      - name: Run tests
+      - name: Run unit-tests
         run: python -m pytest


### PR DESCRIPTION
Changes unit-test workflow to run on `ubuntu-latest`, results in quicker unit testing.