### PR TITLE
Re-add super().init() to ConditionList

### DIFF
--- a/src/dnd.py
+++ b/src/dnd.py
@@ -229,6 +229,7 @@ class ConditionList(DNDObjectList):
     ]
 
     def __init__(self):
+        super().__init__()
         for path in self.paths:
             with open(path, "r") as file:
                 data = json.load(file)


### PR DESCRIPTION
A line was missing in ConditionList, causing the program to crash on startup.