### PR TITLE
Add wakeup status

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -82,7 +82,7 @@ class Bot(discord.Client):
             VC.disable_vc()
 
         await self.change_presence(
-            activity=discord.CustomActivity(name="🎲 Rolling d20s 🎲"),
+            activity=discord.CustomActivity(name="Rolling d20s!"),
             status=discord.Status.online,
         )
         logging.info("Finished initialization")


### PR DESCRIPTION
Makes the bot start with `Do Not Disturb` status, after initialisation changes to `Online` with a status message.
Makes it easier for users to understand that the bot is ready to be used.