### PR TITLE
Add /playsound

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -159,6 +159,11 @@
       "command": "/playsound <audio-file>"
     }
   },
+  "contextmenu": {
+    "reroll": {
+      "name": "Re-roll"
+    }
+  },
   "help": {
     "overview": {
       "name": "Overview",

--- a/cspell.json
+++ b/cspell.json
@@ -2,5 +2,5 @@
   "version": "0.2",
   "language": "en",
   "dictionaries": ["python", "softwareTerms"],
-  "words": ["tokengenurl", "tokengen", "etools", "plansession", "namegen", "playsound"]
+  "words": ["tokengenurl", "tokengen", "etools", "plansession", "namegen", "contextmenu", "playsound"]
 }

--- a/src/bot.py
+++ b/src/bot.py
@@ -263,6 +263,71 @@ class Bot(discord.Client):
             )
             await VC.play_dice_roll(itr, expression, reason)
 
+        @self.tree.context_menu(name=t("contextmenu.reroll.name"))
+        async def reroll(itr: Interaction, message: discord.Message):
+            log_cmd(itr)
+            if message.author.id != itr.client.user.id:
+                await itr.response.send_message(
+                    f"❌ Only works on dice-roll messages sent by {itr.client.user.name} ❌",
+                    ephemeral=True,
+                )
+                return
+
+            if not message.embeds or len(message.embeds) == 0:
+                await itr.response.send_message(
+                    "❌ Reroll doesn't work on this message type!", ephemeral=True
+                )
+                return
+
+            embed = message.embeds[0]
+            title = embed.author.name or ""
+            if not ("Rolling" in title or "Re-rolling" in title):
+                await itr.response.send_message(
+                    "❌ Message does not contain a dice-roll!", ephemeral=True
+                )
+                return
+
+            dice_notation = (
+                title.replace("Rolling ", "").replace("Re-rolling", "").replace("!", "")
+            )
+            if "disadvantage" in dice_notation:
+                # Check 'disadvantage' before 'advantage', may give a false positive otherwise.
+                mode = DiceRollMode.Disadvantage
+                dice_notation = dice_notation.replace("with disadvantage", "")
+            elif "advantage" in dice_notation:
+                mode = DiceRollMode.Advantage
+                dice_notation = dice_notation.replace("with advantage", "")
+            else:
+                mode = DiceRollMode.Normal
+            dice_notation = dice_notation.strip()
+
+            reason = None
+            if "Result" not in embed.fields[0].value:
+                lines = embed.fields[0].value.strip().splitlines()
+                for line in lines:
+                    if line.startswith("🎲") and ":" in line:
+                        label = (
+                            line[1:].split(":", 1)[0].strip()
+                        )  # Remove 🎲 and split before colon
+                        reason = label.replace("*", "")
+                        break
+
+            expression = DiceExpression(
+                expression=dice_notation, mode=mode, reason=reason
+            )
+            expression.title = expression.title.replace("Rolling", "Re-rolling")
+            DiceExpressionCache.store_expression(itr, expression, dice_notation)
+
+            await itr.response.send_message(
+                embed=UserActionEmbed(
+                    itr=itr,
+                    title=expression.title,
+                    description=expression.description,
+                ),
+                ephemeral=expression.ephemeral,
+            )
+            await VC.play_dice_roll(itr, expression, reason)
+
         @roll.autocomplete("diceroll")
         @advantage.autocomplete("diceroll")
         @disadvantage.autocomplete("diceroll")

--- a/src/dice.py
+++ b/src/dice.py
@@ -282,7 +282,7 @@ class DiceExpression(object):
         if reason is None:
             reason = "Result"
 
-        self.description += f"\n🎲 **{reason.capitalize()}: {self.roll.value}**"
+        self.description += f"\n🎲 **{reason.title()}: {self.roll.value}**"
 
         extra_messages = []
         if self.roll.is_natural_twenty:

--- a/test/dice_test.py
+++ b/test/dice_test.py
@@ -106,7 +106,6 @@ class TestDiceExpression:
 
     def test_is_dirty_twenty(self):
         dice = DiceExpression("1000d20kh1ma17+3")
-        print(dice.roll.is_dirty_twenty, dice.roll.roll, dice.is_valid, dice.roll.value)
         assert dice.roll.is_dirty_twenty, "Dice roll should be dirty twenty."
 
     def test_contains_dice(self):

--- a/test/help_test.py
+++ b/test/help_test.py
@@ -1,3 +1,4 @@
+import discord
 from bot import Bot
 import i18n
 
@@ -8,7 +9,11 @@ class TestHelp:
         bot = Bot()
         bot._register_commands()
 
-        command_names = [cmd.name for cmd in bot.tree.get_commands()]
+        command_names = [
+            cmd.name
+            for cmd in bot.tree.get_commands()
+            if isinstance(cmd, discord.app_commands.Command)
+        ]
 
         for name in command_names:
             assert i18n.has(


### PR DESCRIPTION
Adds a simple /playsound command for users to play a sound from an audio-file.

TODO
- [x] Test functionality
- [x] Implement some sort of restrictions, filesize & sound length
- [x] Limit to certain filetypes (mp3, ogg, wav), for simplicity and additional safety.
- [x] Apply normalization and same volume adjustments as base-sounds.

Notes:
Attachments can be cached by saving the discord attachment URL, may be worth looking into so users dont have to re-upload every time. However this warrants a new PR.