### PR TITLE
HOTFIX: Support old homebrew keys

### DIFF
--- a/src/logic/homebrew.py
+++ b/src/logic/homebrew.py
@@ -85,7 +85,9 @@ class HomebrewEntry(object):
         return cls(
             name=data["name"],
             author_id=data["author_id"],
-            entry_type=HomebrewEntryType(data.get("entry_type", None) or data["object_type"]),  # Name conversion requires support for old format.
+            entry_type=HomebrewEntryType(
+                data.get("entry_type", None) or data["object_type"]
+            ),  # Name conversion requires support for old format.
             description=data["description"],
             select_description=data["select_description"],
         )


### PR DESCRIPTION
A recent PR changed `object_type` to `entry_type`.
However because the data in the host version did not have this key, it crashes.