### PR TITLE
Add config sources support to /search class

### DIFF
--- a/src/embeds/dnd/class_.py
+++ b/src/embeds/dnd/class_.py
@@ -13,8 +13,11 @@ class MultiClassSubclassSelect(discord.ui.Select["ClassNavigationView"]):
         subclass: str | None,
         parent_view: "ClassNavigationView",
     ):
+        sources = [f"({src})" for src in parent_view.allowed_sources]
         options: list[discord.SelectOption] = []
         for subclass_name in character_class.subclass_level_features.keys():
+            if not any(src in subclass_name for src in sources):
+                continue  # Skip disallowed source-content.
             if character_class.source == "XPHB" and "(PHB)" in subclass_name:
                 continue  # Do not show PHB subclasses for XPHB classes, unreliable data.
 
@@ -30,7 +33,7 @@ class MultiClassSubclassSelect(discord.ui.Select["ClassNavigationView"]):
     async def callback(self, interaction: discord.Interaction):
         subclass = self.values[0]
         self.parent_view.subclass = subclass
-        embed = ClassEmbed(self.character_class, self.level, subclass)
+        embed = ClassEmbed(self.character_class, self.parent_view.allowed_sources, self.level, subclass)
         await interaction.response.edit_message(embed=embed, view=embed.view)
 
 
@@ -60,18 +63,21 @@ class MultiClassPageSelect(discord.ui.Select["ClassNavigationView"]):
     async def callback(self, interaction: discord.Interaction):
         level = int(self.values[0])
         self.parent_view.level = level
-        embed = ClassEmbed(self.character_class, level, self.subclass)
+        embed = ClassEmbed(self.character_class, self.parent_view.allowed_sources, level, self.subclass)
         await interaction.response.edit_message(embed=embed, view=embed.view)
 
 
 class ClassNavigationView(discord.ui.View):
+    character_class: Class
+    allowed_sources: set[str]
     level: int
     subclass: str | None
 
-    def __init__(self, character_class: Class, level: int, subclass: str | None):
+    def __init__(self, character_class: Class, allowed_sources: set[str], level: int, subclass: str | None):
         super().__init__()
 
         self.character_class = character_class
+        self.allowed_sources = allowed_sources
         self.level = level
         self.subclass = subclass
 
@@ -82,7 +88,7 @@ class ClassNavigationView(discord.ui.View):
 
 
 class ClassEmbed(DNDEntryEmbed):
-    def __init__(self, character_class: Class, level: int = 0, subclass: str | None = None):
+    def __init__(self, character_class: Class, allowed_sources: set[str], level: int = 0, subclass: str | None = None):
         level = max(0, min(20, level))
 
         super().__init__(character_class)
@@ -136,4 +142,4 @@ class ClassEmbed(DNDEntryEmbed):
                 self.add_description_fields(descriptions=descriptions)
 
         self.set_footer(text=f"Page {level + 1} / 21", icon_url="")
-        self.view = ClassNavigationView(character_class, level, subclass)
+        self.view = ClassNavigationView(character_class, allowed_sources, level, subclass)

--- a/src/embeds/search.py
+++ b/src/embeds/search.py
@@ -19,6 +19,7 @@ from embeds.dnd.species import SpeciesEmbed
 from embeds.dnd.spell import SpellEmbed
 from embeds.dnd.table import DNDTableContainerView
 from embeds.dnd.vehicle import VehicleEmbed
+from logic.config import Config
 from logic.dnd.abstract import DNDEntry
 from logic.dnd.action import Action
 from logic.dnd.background import Background
@@ -49,7 +50,8 @@ def get_dnd_embed(itr: discord.Interaction, dnd_entry: DNDEntry):
         case Creature():
             return CreatureEmbed(dnd_entry)
         case Class():
-            return ClassEmbed(dnd_entry)
+            sources = Config.allowed_sources(server=itr.guild)
+            return ClassEmbed(dnd_entry, allowed_sources=sources)
         case Rule():
             return RuleEmbed(dnd_entry)
         case Action():


### PR DESCRIPTION
Closes #473
- Makes it so disallowed sources don't show in the `/search class` subclass-dropdown.
- Additionally fixes `PHB` subclasses from showing under `XPHB` classes. (Since we don't properly scale those like 5e.tools does)