### PR TITLE
Replace discord.ui.TextInput with custom component

### DIFF
--- a/src/components/items.py
+++ b/src/components/items.py
@@ -24,7 +24,7 @@ class SimpleSeparator(discord.ui.Separator[discord.ui.LayoutView]):
             super().__init__(spacing=discord.SeparatorSpacing.small)
 
 
-class LabeledTextComponent(discord.ui.Label[discord.ui.LayoutView]):
+class SimpleLabelTextInput(discord.ui.Label[discord.ui.LayoutView]):
     def __init__(
         self,
         *,

--- a/src/components/modals.py
+++ b/src/components/modals.py
@@ -5,7 +5,7 @@ from discord import Interaction
 from discord.ui import Modal
 
 from commands.command import get_error_embed
-from components.items import LabeledTextComponent
+from components.items import SimpleLabelTextInput
 
 T = TypeVar("T")
 
@@ -20,7 +20,7 @@ class SimpleModal(Modal):
         input_values = {
             child.text: str(child.input)
             for child in self.children
-            if isinstance(child, LabeledTextComponent) and str(child.input) != ""
+            if isinstance(child, SimpleLabelTextInput) and str(child.input) != ""
         }
 
         username = itr.user.name
@@ -31,12 +31,12 @@ class SimpleModal(Modal):
         embed = get_error_embed(error)
         await itr.response.send_message(embed=embed, ephemeral=True)
 
-    def get_str(self, component: LabeledTextComponent) -> str | None:
+    def get_str(self, component: SimpleLabelTextInput) -> str | None:
         """Safely parse string from LabeledTextComponent. Returns None if input is empty or only spaces."""
         text = str(component.input).strip()
         return text if text else None
 
-    def get_int(self, component: LabeledTextComponent) -> int | None:
+    def get_int(self, component: SimpleLabelTextInput) -> int | None:
         """Safely parse integer from LabeledTextComponent. Returns None on failure, defaults to 0 if input is ''"""
         text = str(component.input).strip()
         if text == "":
@@ -46,7 +46,7 @@ class SimpleModal(Modal):
         except ValueError:
             return None
 
-    def get_choice(self, component: LabeledTextComponent, default: T, choices: dict[str, T]) -> T:
+    def get_choice(self, component: SimpleLabelTextInput, default: T, choices: dict[str, T]) -> T:
         """Used to simulate selection-menu functionality, allowing a user to select a certain option."""
         choice = default
         user_input = str(component.input).lower()

--- a/src/components/paginated_view.py
+++ b/src/components/paginated_view.py
@@ -3,19 +3,19 @@ import math
 
 import discord
 
-from components.items import LabeledTextComponent
+from components.items import SimpleLabelTextInput
 from components.modals import SimpleModal
 
 
 class PaginatedJumpModal(SimpleModal):
-    page: LabeledTextComponent
+    page: SimpleLabelTextInput
     view: "PaginatedLayoutView"
 
     def __init__(self, itr: discord.Interaction, view: "PaginatedLayoutView"):
         super().__init__(itr=itr, title="Jump pages")
         self.view = view
         current_page = str(self.view.page + 1)
-        self.page = LabeledTextComponent(
+        self.page = SimpleLabelTextInput(
             label=f"Jump to page (1 - {self.view.max_pages})",
             placeholder=current_page,
             min_length=1,

--- a/src/embeds/homebrew.py
+++ b/src/embeds/homebrew.py
@@ -1,7 +1,7 @@
 import discord
 from discord import ui
 
-from components.items import LabeledTextComponent, SimpleSeparator, TitleTextDisplay
+from components.items import SimpleLabelTextInput, SimpleSeparator, TitleTextDisplay
 from components.modals import SimpleModal
 from components.paginated_view import PaginatedLayoutView
 from logic.homebrew import HomebrewData, HomebrewEntry, HomebrewEntryType
@@ -34,14 +34,14 @@ class HomebrewEmbed(discord.Embed):
 
 class HomebrewEntryAddModal(SimpleModal):
     type: HomebrewEntryType
-    name = LabeledTextComponent(label="Name", placeholder="Peanut")
-    subtitle = LabeledTextComponent(
+    name = SimpleLabelTextInput(label="Name", placeholder="Peanut")
+    subtitle = SimpleLabelTextInput(
         label="Subtitle",
         placeholder="A small legume",
         required=False,
         max_length=80,
     )
-    description = LabeledTextComponent(
+    description = SimpleLabelTextInput(
         label="Description",
         placeholder="A peanut is a legume that is often mistaken for a nut.",
         max_length=4000,
@@ -79,9 +79,9 @@ class HomebrewEntryAddModal(SimpleModal):
 
 class HomebrewEditModal(SimpleModal):
     entry: HomebrewEntry
-    name = LabeledTextComponent(label="Name")
-    subtitle = LabeledTextComponent(label="Subtitle", required=False, max_length=80)
-    description = LabeledTextComponent(label="Description", max_length=4000, style=discord.TextStyle.paragraph)
+    name = SimpleLabelTextInput(label="Name")
+    subtitle = SimpleLabelTextInput(label="Subtitle", required=False, max_length=80)
+    description = SimpleLabelTextInput(label="Description", max_length=4000, style=discord.TextStyle.paragraph)
 
     def __init__(self, itr: discord.Interaction, entry: HomebrewEntry):
         self.entry = entry

--- a/src/embeds/initiative.py
+++ b/src/embeds/initiative.py
@@ -1,7 +1,7 @@
 import discord
 from discord import Interaction, ui
 
-from components.items import LabeledTextComponent, SimpleSeparator
+from components.items import SimpleLabelTextInput, SimpleSeparator
 from components.modals import SimpleModal
 from embeds.embed import SimpleEmbed, UserActionEmbed
 from logger import log_button_press
@@ -17,14 +17,14 @@ class _InitiativeModal(SimpleModal):
 
 
 class InitiativeRollModal(_InitiativeModal):
-    modifier = LabeledTextComponent(label="Your Initiative Modifier", placeholder="0", max_length=2, required=False)
-    name = LabeledTextComponent(
+    modifier = SimpleLabelTextInput(label="Your Initiative Modifier", placeholder="0", max_length=2, required=False)
+    name = SimpleLabelTextInput(
         label="Name (Username by default)",
         placeholder="Goblin",
         required=False,
         max_length=128,
     )
-    advantage = LabeledTextComponent(
+    advantage = SimpleLabelTextInput(
         label="Roll Mode (Normal by default)",
         placeholder="Advantage / Disadvantage",
         required=False,
@@ -83,8 +83,8 @@ class InitiativeRollModal(_InitiativeModal):
 
 
 class InitiativeSetModal(_InitiativeModal):
-    value = LabeledTextComponent(label="Initiative value", placeholder="20", max_length=3)
-    name = LabeledTextComponent(
+    value = SimpleLabelTextInput(label="Initiative value", placeholder="20", max_length=3)
+    name = SimpleLabelTextInput(
         label="Name (Username by default)",
         placeholder="Goblin",
         required=False,
@@ -119,7 +119,7 @@ class InitiativeSetModal(_InitiativeModal):
 
 
 class InitiativeDeleteModal(_InitiativeModal):
-    name = LabeledTextComponent(
+    name = SimpleLabelTextInput(
         label="Name (Username by default)",
         placeholder="Goblin",
         required=False,
@@ -145,21 +145,21 @@ class InitiativeDeleteModal(_InitiativeModal):
 
 
 class InitiativeBulkModal(_InitiativeModal):
-    modifier = LabeledTextComponent(
+    modifier = SimpleLabelTextInput(
         label="Creature's Initiative Modifier",
         placeholder="0",
         max_length=3,
         required=False,
     )
-    name = LabeledTextComponent(label="Creature's Name", placeholder="Goblin", max_length=128)
-    amount = LabeledTextComponent(label="Amount of creatures to add", placeholder="1", max_length=2)
-    advantage = LabeledTextComponent(
+    name = SimpleLabelTextInput(label="Creature's Name", placeholder="Goblin", max_length=128)
+    amount = SimpleLabelTextInput(label="Amount of creatures to add", placeholder="1", max_length=2)
+    advantage = SimpleLabelTextInput(
         label="Roll Mode (Normal by default)",
         placeholder="Advantage / Disadvantage",
         required=False,
         max_length=12,
     )
-    shared = LabeledTextComponent(
+    shared = SimpleLabelTextInput(
         label="Share Initiative (False by default)",
         placeholder="True / False",
         required=False,
@@ -213,7 +213,7 @@ class InitiativeBulkModal(_InitiativeModal):
 
 
 class InitiativeClearConfirmModal(_InitiativeModal):
-    confirm = LabeledTextComponent(label="Type 'CLEAR' to confirm", placeholder="CLEAR")
+    confirm = SimpleLabelTextInput(label="Type 'CLEAR' to confirm", placeholder="CLEAR")
 
     def __init__(self, itr: Interaction, tracker: InitiativeTracker):
         super().__init__(itr, title="Are you sure you want to clear?", tracker=tracker)


### PR DESCRIPTION
This component is a label wrapped a discord.ui.TextInput, which should prevent the textinput.label deprecation warnings.

Closes #299 

Also closes #325, which does the same thing