### PR TITLE
Add basic dice notation support to coin

### DIFF
--- a/lenny/commands/coin.py
+++ b/lenny/commands/coin.py
@@ -11,7 +11,7 @@ class CoinCommand(BaseCommand):
     desc = "Perform D&D currency math!"
     help = "Calculate your pieces using addition, subtraction, division and multiplication!"
 
-    @describe(expression="Units: cp, sp, ep, gp, pp; Operators: + - * /")
+    @describe(expression="Units: cp, sp, ep, gp, pp; Operators: + - * /; Also supports dice expressions: 1d20, ...")
     async def handle(self, itr: discord.Interaction, expression: str):
         coin = Coin.from_string(expression)
         embed = UserActionEmbed(itr, title=expression.lower(), description=str(coin))

--- a/lenny/logic/coin.py
+++ b/lenny/logic/coin.py
@@ -5,22 +5,27 @@ from typing import TypeAlias
 
 from lark import Lark, LarkError, Token, Transformer, Tree
 
+from logic.roll import roll
+
+# TODO Only supports basic dice expressions, should potentially also support modifiers (explode, keep, drop, roll over...)
 COIN_GRAMMAR = r"""
     ?start: expr
 
     ?expr: term
-         | expr "+" term   -> add
-         | expr "-" term   -> sub
+         | expr "+" term    -> add
+         | expr "-" term    -> sub
 
     ?term: factor
-         | term "*" factor -> mul
-         | term "/" factor -> div
+         | term "*" factor  -> mul
+         | term "/" factor  -> div
 
-    ?factor: NUMBER        -> number
-           | COIN_UNIT     -> coin
+    ?factor: NUMBER         -> number
+           | COIN_UNIT      -> coin
+           | DICE           -> dice
            | "(" expr ")"
 
     COIN_UNIT.10: /[\d.]+(pp|gp|ep|sp|cp)/
+    DICE.20: /\d+d\d+/
 
     %import common.NUMBER
     %import common.WS
@@ -40,6 +45,10 @@ class CoinTransformer(Transformer[EvalResult]):  # pyright: ignore[reportInvalid
 
     def coin(self, items: list[Token]) -> Coin:
         return Coin.parse_unit(str(items[0]))
+
+    def dice(self, items: list[Token]) -> float:
+        expr = str(items[0])
+        return roll(expr).result.total
 
     def add(self, args: list[EvalResult]) -> EvalResult:
         if isinstance(args[0], float | int):

--- a/lenny/logic/coin.py
+++ b/lenny/logic/coin.py
@@ -7,7 +7,6 @@ from lark import Lark, LarkError, Token, Transformer, Tree
 
 from logic.roll import roll
 
-# TODO Only supports basic dice expressions, should potentially also support modifiers (explode, keep, drop, roll over...)
 COIN_GRAMMAR = r"""
     ?start: expr
 
@@ -25,7 +24,7 @@ COIN_GRAMMAR = r"""
            | "(" expr ")"
 
     COIN_UNIT.10: /[\d.]+(pp|gp|ep|sp|cp)/
-    DICE.20: /\d+d\d+/
+    DICE.20: /\d+d\d+[a-zA-Z0-9<>=!]*/
 
     %import common.NUMBER
     %import common.WS

--- a/lenny/logic/help.py
+++ b/lenny/logic/help.py
@@ -308,6 +308,7 @@ class HelpTabList:
                     "- **Brackets** are also supported for more precise maths. (e.g. ``(50gp - 5gp) / 2``)",
                     "- If the value of a piece isn't specified in a subtraction or addition, it default to **CP**. (e.g. ``1cp - 1 = 0cp``)",
                     "- Results of calculations are always rounded up.",
+                    "- You can also use dice-expressions within your coin-expression for random values. (e.g. ``1d20 * 25gp``). A dice expression that isn't multiplied with coin, will be treated as a random number of **CP**.",
                 ],
             ),
         ],

--- a/readme.md
+++ b/readme.md
@@ -196,6 +196,6 @@ Command to help track initiatives for combat. Names are enforced to be unique an
   - `Clear Rolls` - Clears all stored initiatives in the server, used after a battle.
 
 ### Coin Calculation
-Perform calculations on your D&D currency directly using coin expressions. Examples of a coin expression are `2pp + 5gp - 3sp` or `10gp * 1.2`.
+Perform calculations on your D&D currency directly using coin expressions. Examples of a coin expression are `2pp + 5gp - 3sp`, `10gp * 1.2` or `500gp + (1d20 * 25gp)`.
 
 - `/coin <expression>` - Evaluate a coin expression and automatically convert the result into the optimal denominations.

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -191,12 +191,7 @@ SLASH_COMMAND_TESTS: Iterable[Iterable[Any]] = [
     (
         "coin",
         {
-            "expression": [
-                "10gp - 5gp",
-                "10gp + 5gp",
-                "10gp / 2",
-                "10gp * 2",
-            ],
+            "expression": ["10gp - 5gp", "10gp + 5gp", "10gp / 2", "10gp * 2", "1d20 * 25gp"],
         },
     ),
     # Homebrew commands work through modals, and are thus not testable.


### PR DESCRIPTION
Closes #925

Currently on hold, this logic needs a big rewrite, current implementation makes it hard to expand.

TODO:
- [x] Currently only works for basic ``xdy`` notations, "needs" modifier support.
- [ ] If a diceroll was used, the user should probably be shown the evaluated result of that diceroll.